### PR TITLE
ACF-7 # by default, fetch errors are non-fatal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Options:
   -h, --help     output usage information
   -V, --version  output the version number
   -f, --force    wipe `output' if it already exists, create if needed
+  -s, --strict   consider fetch errors as fatal
 ```
 
 ### example

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ program
   outputPath = output;
 })
 .option('-f, --force', 'wipe `output\' if it already exists, create if needed')
+.option('-s, --strict', 'consider fetch errors as fatal')
 .parse(process.argv);
 
 (function () {
@@ -60,7 +61,11 @@ if (fs.existsSync(outputPath)) {
   rimraf.sync(outputPath);
 }
 
-fetcher = new Fetcher({ remoteUrl: remoteUrl, localPath: outputPath });
+fetcher = new Fetcher({
+  localPath: outputPath,
+  remoteUrl: remoteUrl,
+  strictMode: !!program.strict
+});
 
 fetcher.go()
 .then(function () {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/blinkmobile/appcache-fetcher.js#readme",
   "dependencies": {
-    "@jokeyrhyme/appcache-fetcher": "1.2.1",
+    "@jokeyrhyme/appcache-fetcher": "1.3.0",
     "cheerio": "0.19.0",
     "commander": "2.9.0",
     "rimraf": "2.4.4"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@jokeyrhyme/appcache-fetcher": "1.2.1",
     "cheerio": "0.19.0",
-    "commander": "2.8.1",
-    "rimraf": "2.4.3"
+    "commander": "2.9.0",
+    "rimraf": "2.4.4"
   },
   "devDependencies": {
     "@jokeyrhyme/appcache": "^1.0",
@@ -28,7 +28,8 @@
     "eslint": "^1.1",
     "eslint-config-semistandard": "^5.0",
     "eslint-config-standard": "^4.0",
-    "istanbul": "^0.3",
+    "eslint-plugin-standard": "1.3.1",
+    "istanbul": "^0.4",
     "tape": "^4.0",
     "tape-chai": "^1.1"
   },


### PR DESCRIPTION
- users can enable "strict mode" where fetch errors will stop everything with the "-s" CLI flag
- fetch errors are also reported in red colour
