### PR TITLE
ACF-13 # bump deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["eslint:recommended", "semistandard"],
+  "extends": ["eslint:recommended", "standard"],
   "env": {
     "amd": true,
     "browser": false,
@@ -11,6 +11,10 @@
   },
   "rules": {
     /* Node.JS */
-    "no-sync": 2
+    "no-sync": 2,
+
+    "semi": [2, "always"],
+    "no-extra-semi": 2,
+    "semi-spacing": [2, { "before": false, "after": true }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,17 +12,16 @@
     "@jokeyrhyme/appcache-fetcher": "2.0.0",
     "cheerio": "0.20.0",
     "commander": "2.9.0",
-    "rimraf": "2.5.2",
+    "rimraf": "2.5.4",
     "through2": "2.0.1",
     "update-notifier": "^1.0.0"
   },
   "devDependencies": {
     "@jokeyrhyme/appcache": "^1.0",
-    "eslint": "^2.7",
-    "eslint-config-semistandard": "^6.0",
-    "eslint-config-standard": "^5.1",
-    "eslint-plugin-promise": "^1.1",
-    "eslint-plugin-standard": "^1.3",
+    "eslint": "^3.2.2",
+    "eslint-config-standard": "^5.3.5",
+    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-standard": "^2.0.0",
     "fixpack": "^2.3.1",
     "greenkeeper-postpublish": "^1.0.0",
     "istanbul": "^0.4",
@@ -57,8 +56,8 @@
   "scripts": {
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
+    "postpublish": "greenkeeper-postpublish",
     "posttest": "npm run eslint && npm run fixpack",
-    "test": "istanbul cover ./tests/",
-    "postpublish": "greenkeeper-postpublish"
+    "test": "istanbul cover ./tests/"
   }
 }

--- a/tests/00_blinkm_co_integration.js
+++ b/tests/00_blinkm_co_integration.js
@@ -23,6 +23,13 @@ var Fetcher = require(path.join(__dirname, '..', 'lib', 'fetcher'));
 var OUTPUT_PATH = path.join(__dirname, '..', 'output');
 var REMOTE_URL = 'https://blinkm.co/integration';
 
+function errorThenEnd (tt) {
+  return function (err) {
+    tt.error(err);
+    tt.end();
+  };
+}
+
 test(REMOTE_URL, function (t) {
   var fetcher;
   var manifestUrl;
@@ -56,10 +63,7 @@ test(REMOTE_URL, function (t) {
       tt.ok(manifestUrl);
       tt.isString(manifestUrl);
       tt.end();
-    }).catch(function (err) {
-      tt.error(err);
-      tt.end();
-    });
+    }).catch(errorThenEnd(tt));
   });
 
   t.test('#download() AppCache Manifest', function (tt) {
@@ -81,10 +85,7 @@ test(REMOTE_URL, function (t) {
       tt.ok(contents);
       tt.isString(contents);
       tt.end();
-    }).catch(function (err) {
-      tt.error(err);
-      tt.end();
-    });
+    }).catch(errorThenEnd(tt));
   });
 
   t.test('AppCache.parse() AppCache Manifest', function (tt) {
@@ -127,10 +128,7 @@ test(REMOTE_URL, function (t) {
         'cordova.js'
       ]);
       tt.end();
-    }).catch(function (err) {
-      tt.error(err);
-      tt.end();
-    });
+    }).catch(errorThenEnd(tt));
   });
 
   t.end();


### PR DESCRIPTION
### Changed
- bumped [rimraf](https://www.npmjs.com/package/rimraf) to 2.5.4 (#20, @jokeyrhyme)
### Code Review Notes
- also bump ESLint, etc
- dropped ESLint SemiStandard in favour of embedding the rules directly, as there are currently some peerDependency version constraints that make things tricky
